### PR TITLE
change the git url after changing the project name to boros-CMP

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/scm-spain/CMP.git"
+    "url": "https://github.com/scm-spain/boros-CMP.git"
   },
   "keywords": [
     "ads",


### PR DESCRIPTION
# Background

Update the project's github url after changing it