### PR TITLE
Make cmp-boros importable from server-side

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
+dist: trusty
 language: node_js
 node_js:
   - "8"
 cache:
   directories:
-  - node_modules
+    - node_modules
+before_install:
+  - npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
 script:
   - npm run lint
   - npm test
   - npm run coverage:ci
+  - |
+    echo TRAVIS_BRANCH=$TRAVIS_BRANCH - TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST - TRAVIS_TAG=$TRAVIS_TAG
+    if [[ $TRAVIS_TAG =~ v[0-9]+\.[0-9]+.[0-9]+ ]]; then
+      echo DEPLOY TO NPM: $TRAVIS_TAG
+      npm publish
+    fi
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Boros CMP
 
-[![Build status](https://travis-ci.org/scm-spain/CMP.svg?branch=master)](https://travis-ci.org/scm-spain/CMP)
-[![codecov](https://codecov.io/gh/scm-spain/CMP/branch/master/graph/badge.svg)](https://codecov.io/gh/scm-spain/CMP)
-[![GitHub license](https://img.shields.io/github/license/scm-spain/CMP.svg)](https://github.com/scm-spain/CMP/blob/master/LICENSE)
+[![Build status](https://travis-ci.org/scm-spain/Boros-CMP.svg?branch=master)](https://travis-ci.org/scm-spain/Boros-CMP)
+[![codecov](https://codecov.io/gh/scm-spain/Boros-CMP/branch/master/graph/badge.svg)](https://codecov.io/gh/scm-spain/Boros-CMP)
+[![GitHub license](https://img.shields.io/github/license/scm-spain/Boros-CMP.svg)](https://github.com/scm-spain/Boros-CMP/blob/master/LICENSE)
 [![npm version](https://img.shields.io/npm/v/@schibstedspain/boros-cmp.svg)](https://www.npmjs.com/package/@schibstedspain/boros-cmp)
 
 ## Table of Contents

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/boros-cmp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/boros-cmp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Schibsted GDPR - Consent Management Provider - Standalone",
   "main": "dist/cmp.pro.js",
   "scripts": {

--- a/src/cmp/infrastructure/event-polyfill.js
+++ b/src/cmp/infrastructure/event-polyfill.js
@@ -1,4 +1,4 @@
-if (window && typeof window.CustomEvent !== 'function') {
+if (typeof window !== 'undefined' && typeof window.CustomEvent !== 'function') {
   const CustomEvent = (event, params) => {
     const eventParams = params || {
       bubbles: false,

--- a/src/global.js
+++ b/src/global.js
@@ -1,3 +1,3 @@
 /* eslint-disable no-undef */
 import bootstrap from './globalstorage/infrastructure/bootstrap'
-bootstrap(window)
+typeof window !== 'undefined' && bootstrap(window)


### PR DESCRIPTION
# Background

Library is not compatible with server-side rendering as it's using `window` freely while it could be not defined.

# Goal

Make the library importable from server in order to try to import it as soon as possible, in the same chunk as the principal bundle.

# Implementation

Use safe check against window being undefined.

# Further considerations

All the functionality remains the same.

# Visual Description

![image](https://user-images.githubusercontent.com/1561955/59045219-ea9ea380-887f-11e9-924a-89204d350ce1.png)
