### PR TITLE
hot fix wrong consent-string version with issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,9 +81,9 @@
     ]
   },
   "dependencies": {
-    "@s-ui/polyfills": "^1.9.0",
-    "consent-string": "^1.2.4",
+    "@s-ui/polyfills": "1",
+    "consent-string": "1.4.2",
     "isomorphic-unfetch": "3.0.0",
-    "uuid": "^3.3.2"
+    "uuid": "3.3.2"
   }
 }


### PR DESCRIPTION
Newest consent-string 1.4.3 version has problems and making CMP to not work correctly. This fixes the version to the last known without problems.