### PR TITLE
Hotfix/purposes translation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,28 +1,18 @@
-# Background
+## Description
+<!--- Explain why this PR has to be merged, what originated this feature, ... -->
 
-X
+## Solves ticket/s
+<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->
 
-# Goal
+## Expected behavior
+<!--- Add information of what's expected to happen when this is merged -->
 
-X
+## Review steps
+<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->
 
-# Implementation
+## Further considerations
+<!--- If applies, add information of breaking changes, agreed deploy timings, ...  -->
 
-X
-
-# Further considerations
-
-X
-
-# Checklist
-
-- [ ] The PR relates to *only* one subject with a clear title.
-- [ ] I have performed a self-review of my own code
-- [ ] Wrote [good commit messages](http://chris.beams.io/posts/git-commit/)
-- [ ] My code is readable by someone else, and I commented the hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] I have added tests that prove my fix is effective or that my feature works
-
-# Visual Description
-
-![]()
+## Memetized description
+<!--- Mandatory gif, try https://giphy.com/  -->
+![mandatory]()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/boros-cmp",
-  "version": "1.1.2",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4669,8 +4669,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4691,14 +4690,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4713,20 +4710,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4843,8 +4837,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4856,7 +4849,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4871,7 +4863,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4879,14 +4870,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4905,7 +4894,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4986,8 +4974,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4999,7 +4986,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5085,8 +5071,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5122,7 +5107,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5142,7 +5126,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5186,14 +5169,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/boros-cmp",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Schibsted GDPR - Consent Management Provider - Standalone",
   "main": "dist/cmp.pro.js",
   "scripts": {

--- a/src/cmp/infrastructure/container/BaseConsentContainer.js
+++ b/src/cmp/infrastructure/container/BaseConsentContainer.js
@@ -1,3 +1,4 @@
+import fetch from 'isomorphic-unfetch'
 import DomainEventBus from '../../domain/event_bus/DomainEventBus'
 import GetConsentDataUseCase from '../../application/services/consent/GetConsentDataUseCase'
 import ChainedVendorListRepository from '../repository/ChainedVendorListRepository'
@@ -18,6 +19,7 @@ import ConsentFactory from '../../domain/consent/ConsentFactory'
 import VendorConsentsFactory from '../../domain/vendor_consents/VendorConsentsFactory'
 import {Log} from '../service/log/Log'
 import {globalVendorListVersionChangedObserverFactory} from '../observer/globalVendorListVersionChangedObserverFactory'
+import HttpTranslationVendorListRepository from '../repository/HttpTranslationVendorListRepository'
 
 export default class BaseConsentContainer {
   constructor({config, cmpVersion, window, eager = true} = {}) {
@@ -61,7 +63,7 @@ export default class BaseConsentContainer {
         key: 'InMemoryVendorListRepository'
       }),
       httpVendorListRepository: this.getInstance({
-        key: 'HttpVendorListRepository'
+        key: 'HttpTranslationVendorListRepository'
       })
     })
   }
@@ -72,8 +74,17 @@ export default class BaseConsentContainer {
 
   _buildHttpVendorListRepository() {
     return new HttpVendorListRepository({
+      fetcher: fetch,
       vendorListHost: this._config.vendorList.host,
       vendorListFilename: this._config.vendorList.filename
+    })
+  }
+
+  _buildHttpTranslationVendorListRepository() {
+    return new HttpTranslationVendorListRepository({
+      fetcher: fetch,
+      consentLanguage: this._config.consent.consentLanguage,
+      vendorListRepository: this.getInstance({key: 'HttpVendorListRepository'})
     })
   }
 

--- a/src/cmp/infrastructure/repository/HttpTranslationVendorListRepository.js
+++ b/src/cmp/infrastructure/repository/HttpTranslationVendorListRepository.js
@@ -1,0 +1,69 @@
+export default class HttpTranslationVendorListRepository {
+  constructor({fetcher, vendorListRepository, consentLanguage} = {}) {
+    this._fetcher = fetcher
+    this._vendorListRepository = vendorListRepository
+    this._consentLanguage = consentLanguage
+    this._acceptedLanguage = ACCEPTED_LANGUAGES.has(this._consentLanguage)
+  }
+
+  getGlobalVendorList({vendorListVersion} = {}) {
+    return Promise.all([
+      this._vendorListRepository.getGlobalVendorList({vendorListVersion}),
+      this._acceptedLanguage ? this._getTranslation({vendorListVersion}) : null
+    ]).then(
+      ([vendorList, translation]) =>
+        translation
+          ? this._mergeTranslation({vendorList, translation})
+          : vendorList
+    )
+  }
+
+  _getTranslation({vendorListVersion}) {
+    return Promise.resolve()
+      .then(
+        () =>
+          `${PURPOSES_HOST}/${
+            vendorListVersion ? 'v-' + vendorListVersion + '/' : ''
+          }${PURPOSES_FILENAME}-${this._consentLanguage}${PURPOSES_EXTENSION}`
+      )
+      .then(url => this._fetcher(url))
+      .then(fetchResponse => (fetchResponse.ok ? fetchResponse.json() : null))
+  }
+
+  _mergeTranslation({vendorList, translation}) {
+    return Promise.resolve().then(() => {
+      vendorList.purposes = translation.purposes
+      vendorList.features = translation.features
+      return vendorList
+    })
+  }
+}
+
+const ACCEPTED_LANGUAGES = new Set([
+  'bg',
+  'cs',
+  'da',
+  'de',
+  'el',
+  'es',
+  'et',
+  'fi',
+  'fr',
+  'ga',
+  'hr',
+  'hu',
+  'it',
+  'lt',
+  'lv',
+  'mt',
+  'nl',
+  'pl',
+  'pt',
+  'ro',
+  'sk',
+  'sl',
+  'sv'
+])
+const PURPOSES_HOST = 'https://vendorlist.consensu.org'
+const PURPOSES_FILENAME = 'purposes'
+const PURPOSES_EXTENSION = '.json'

--- a/src/cmp/infrastructure/repository/HttpVendorListRepository.js
+++ b/src/cmp/infrastructure/repository/HttpVendorListRepository.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-import 'isomorphic-unfetch'
 import GlobalVendorListAccessError from '../../domain/vendor_list/GlobalVendorListAccessError'
 
 /**
@@ -7,7 +5,8 @@ import GlobalVendorListAccessError from '../../domain/vendor_list/GlobalVendorLi
  * @implements VendorListRepository
  */
 export default class HttpVendorListRepository {
-  constructor({vendorListHost, vendorListFilename}) {
+  constructor({fetcher, vendorListHost, vendorListFilename}) {
+    this._fetcher = fetcher
     this._vendorListHost = vendorListHost
     this._vendorListFilename = vendorListFilename
   }
@@ -19,13 +18,9 @@ export default class HttpVendorListRepository {
         '/' +
         this._vendorListFilename
     )
-      .then(this._loadURL)
+      .then(url => this._fetcher(url))
       .then(filterOkFetchResponse)
       .then(fetchResponse => fetchResponse.json())
-  }
-
-  _loadURL(url) {
-    return fetch(url)
   }
 }
 

--- a/src/test/cmp/infrastructure/repository/HttpTranslationVendorListRepositoryTest.js
+++ b/src/test/cmp/infrastructure/repository/HttpTranslationVendorListRepositoryTest.js
@@ -1,0 +1,105 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+import GlobalVendorList from '../../../resources/globalvendorlist.json'
+import TranslationES from '../../../resources/purposes-es.json'
+import HttpTranslationVendorListRepository from '../../../../cmp/infrastructure/repository/HttpTranslationVendorListRepository'
+
+describe('HttpTranslationVendorListRepository', () => {
+  describe('getGlobalVendorList', () => {
+    it('should load the remote vendor list and the translation file for the vendor list version and the specified language', done => {
+      const givenConsentLanguage = 'es'
+      const givenVendorListVersion = 74
+      const expectedTranslationsUrl =
+        'https://vendorlist.consensu.org/v-74/purposes-es.json'
+      const fetchTranslationMock = {
+        fetch: () => ({
+          json: () => TranslationES,
+          ok: true
+        })
+      }
+      const fetchTranslationSpy = sinon.spy(fetchTranslationMock, 'fetch')
+      const vendorListMock = {
+        getGlobalVendorList: () => Promise.resolve(GlobalVendorList)
+      }
+      const repository = new HttpTranslationVendorListRepository({
+        fetcher: fetchTranslationMock.fetch,
+        vendorListRepository: vendorListMock,
+        consentLanguage: givenConsentLanguage
+      })
+      repository
+        .getGlobalVendorList({vendorListVersion: givenVendorListVersion})
+        .then(vendorList => {
+          expect(vendorList.vendors).to.deep.equal(GlobalVendorList.vendors)
+          expect(vendorList.purposes).to.deep.equal(TranslationES.purposes)
+          expect(vendorList.features).to.deep.equal(TranslationES.features)
+          expect(vendorList.vendorListVersion).to.deep.equal(
+            GlobalVendorList.vendorListVersion
+          )
+          expect(fetchTranslationSpy.calledOnce).to.be.true
+          expect(
+            fetchTranslationSpy.args[0][0],
+            'incorrect translations URL'
+          ).to.equal(expectedTranslationsUrl)
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
+    it('should load the remote vendor list without translation if the given language is not accepted', done => {
+      const givenConsentLanguage = 'xx'
+      const givenVendorListVersion = 74
+      const fetchTranslationMock = {
+        fetch: () => ({
+          json: () => null,
+          ok: false
+        })
+      }
+      const vendorListMock = {
+        getGlobalVendorList: () => Promise.resolve(GlobalVendorList)
+      }
+      const repository = new HttpTranslationVendorListRepository({
+        fetcher: fetchTranslationMock.fetch,
+        vendorListRepository: vendorListMock,
+        consentLanguage: givenConsentLanguage
+      })
+      repository
+        .getGlobalVendorList({vendorListVersion: givenVendorListVersion})
+        .then(vendorList => {
+          expect(vendorList).to.deep.equal(GlobalVendorList)
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
+    it('should load the no-version translations if no vendor list version is specified', done => {
+      const givenConsentLanguage = 'es'
+      const givenVendorListVersion = undefined
+      const expectedTranslationsUrl =
+        'https://vendorlist.consensu.org/purposes-es.json'
+      const fetchTranslationMock = {
+        fetch: () => ({
+          json: () => TranslationES,
+          ok: true
+        })
+      }
+      const fetchTranslationSpy = sinon.spy(fetchTranslationMock, 'fetch')
+      const vendorListMock = {
+        getGlobalVendorList: () => Promise.resolve(GlobalVendorList)
+      }
+      const repository = new HttpTranslationVendorListRepository({
+        fetcher: fetchTranslationMock.fetch,
+        vendorListRepository: vendorListMock,
+        consentLanguage: givenConsentLanguage
+      })
+      repository
+        .getGlobalVendorList({vendorListVersion: givenVendorListVersion})
+        .then(vendorList => {
+          expect(fetchTranslationSpy.calledOnce).to.be.true
+          expect(
+            fetchTranslationSpy.args[0][0],
+            'incorrect translations URL'
+          ).to.equal(expectedTranslationsUrl)
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
+  })
+})

--- a/src/test/cmp/infrastructure/repository/HttpVendorListRepositoryTest.js
+++ b/src/test/cmp/infrastructure/repository/HttpVendorListRepositoryTest.js
@@ -9,11 +9,6 @@ describe('HttpVendorListRepository', () => {
       const givenVendorListFilename = 'givenVendorList.json'
       const expectedUrl = 'http://cmp.schibsted.com/givenVendorList.json'
 
-      const repository = new HttpVendorListRepository({
-        vendorListFilename: givenVendorListFilename,
-        vendorListHost: givenVendorListHost
-      })
-
       const expectedResult = {
         key: 'value'
       }
@@ -24,7 +19,12 @@ describe('HttpVendorListRepository', () => {
         })
       }
       const fetchSpy = sinon.spy(fetchMock, 'fetch')
-      global.fetch = fetchMock.fetch
+
+      const repository = new HttpVendorListRepository({
+        fetcher: fetchMock.fetch,
+        vendorListFilename: givenVendorListFilename,
+        vendorListHost: givenVendorListHost
+      })
 
       repository
         .getGlobalVendorList()
@@ -49,18 +49,18 @@ describe('HttpVendorListRepository', () => {
       const givenVendorListHost = 'http://cmp.schibsted.com'
       const givenVendorListFilename = 'givenVendorList.json'
 
-      const repository = new HttpVendorListRepository({
-        vendorListFilename: givenVendorListFilename,
-        vendorListHost: givenVendorListHost
-      })
-
       const fetchMock = {
         fetch: () => ({
           json: () => null,
           ok: false
         })
       }
-      global.fetch = fetchMock.fetch
+
+      const repository = new HttpVendorListRepository({
+        fetcher: fetchMock.fetch,
+        vendorListFilename: givenVendorListFilename,
+        vendorListHost: givenVendorListHost
+      })
 
       repository
         .getGlobalVendorList()

--- a/src/test/resources/purposes-es.json
+++ b/src/test/resources/purposes-es.json
@@ -1,0 +1,48 @@
+{
+  "vendorListVersion": 74,
+  "lastUpdated": "2018-06-27T16:20:27Z",
+  "purposes": [
+    {
+      "id": 1,
+      "name": "Almacenamiento y acceso a la información",
+      "description": "El almacenamiento de información, o el acceso a información que ya está almacenada en su dispositivo, como identificadores de publicidad, identificadores de dispositivos, cookies y tecnologías similares."
+    },
+    {
+      "id": 2,
+      "name": "Personalización",
+      "description": "La recogida y el tratamiento de información sobre su uso de este servicio para posteriormente personalizar la publicidad y/o el contenido dirigido a usted en otros contextos, como en otros sitios web o aplicaciones, a lo largo del tiempo. Normalmente, el contenido del sitio o la aplicación se usan para deducir sus intereses, que informan de selecciones futuras de publicidad y/o contenido."
+    },
+    {
+      "id": 3,
+      "name": "Selección, envío, informe de anuncio",
+      "description": "La recogida de información, y la combinación con información previamente recogida, para seleccionar y enviarle anuncios, y para medir el envío y la eficacia de dichos anuncios. Esto incluye usar información previamente recogida sobre sus intereses para seleccionar anuncios, tratar datos sobre los anuncios que se han mostrado, con qué frecuencia se han mostrado, cuándo y dónde se han mostrado y si realizó alguna acción relacionada con el anuncio, incluido, por ejemplo, hacer clic en un anuncio o hacer una compra. Esto no incluye la Personalización, que es la recogida y el tratamiento de información sobre su uso de este servicio para personalizar posteriormente la publicidad y/o el contenido dirigido a usted en otros contextos, como sitios web o aplicaciones, a lo largo del tiempo."
+    },
+    {
+      "id": 4,
+      "name": "Selección, envío, informe de contenido",
+      "description": "La recogida de información y la combinación con información previamente recogida, para seleccionar y enviarle contenido, y para medir el envío y la eficacia de dicho contenido. Esto incluye usar información previamente recogida sobre sus intereses para seleccionar contenido, tratar datos sobre qué contenido se ha mostrado, con qué frecuencia y durante cuánto tiempo se ha mostrado, cuándo y dónde se ha mostrado y si realizó alguna acción relacionada con el contenido, incluido, por ejemplo, hacer clic en el contenido. Esto no incluye la Personalización, que es la recogida y el tratamiento de información sobre su uso de este servicio para personalizar posteriormente el contenido y/o la publicidad dirigida a usted en otros contextos, como sitios web o aplicaciones, a lo largo del tiempo."
+    },
+    {
+      "id": 5,
+      "name": "Medición",
+      "description": "La recogida de información sobre el uso de contenido por su parte y la combinación con información previamente recogida, usada para medir, entender e informar sobre su utilización del contenido. Esto no incluye la Personalización, la recogida de información sobre su uso de este servicio para personalizar posteriormente el contenido y/o la publicidad dirigida a usted en otros contextos, es decir, en otros servicios, como sitios web o aplicaciones, a lo largo del tiempo."
+    }
+  ],
+  "features": [
+    {
+      "id": 1,
+      "name": "Cotejo de datos sin conexión",
+      "description": "La combinación de datos de fuentes sin conexión que se recogieron inicialmente en otros contextos con datos recogidos con conexión en apoyo de uno o más fines."
+    },
+    {
+      "id": 2,
+      "name": "Vinculación de dispositivos",
+      "description": "Tratamiento de datos para vincular múltiples dispositivos que pertenecen al mismo usuario en apoyo de uno o más fines."
+    },
+    {
+      "id": 3,
+      "name": "Datos de localización geográficos precisos",
+      "description": "Recogida y mantenimiento de datos precisos de localización geográfica en apoyo de uno o más fines."
+    }
+  ]
+}


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

Actually the Vendor List is loaded as it is, with its texts in English, aware of the consentLanguage attribute, that is set to 'es' by default.

This PR adds a decorator over the HttpVendorListRepository in order to load (if required) the external purposes translation related to the vendorListVersion and consentLanguage that we need to load in the Vendor List.

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* <https://jira.scmspain.com/browse/PSP-2507>

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

* The getVendorList command is invoked as usual (with or without vendorListVersion)
* The vendor list is expected to exist at the in-memory repo, or to be loaded of the remote JSON
* When loading the remote JSON, if the consentLanguage is one of the available languages of the IAB's purpose translations, the remote purpose JSON is loaded for a specific version and language to fit the vendor list JSON vendorListVersion and the configured language
* The purposes and features texts of the vendor list are replaced with the translations
* The vendor list is returned with the language support

## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

* Open any of the sites using the boros-cmp, cleaning the cookies
* The CMP banner should be shown, and when opening the advertising partners, the purposes and features should be shown in the configured language (it's done at the site's side)
* When a request to <https://vendorlist.consensu.org/v-XXX/vendorlist.json> is done (v-XXX specifies a version number, or empty when loading the latest vendorlist), a request to <https://vendorlist.consensu.org/v-XXX/purposes-YY.json> has to be done if the consentLanguage is available in the IAB translations (being XXX the same vendor list version, and YY the consentLanguage 2 letter code)

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/12Gyf1xVsXp6bm/giphy.gif)