### PR TITLE
Hotfix/http resources downloaded twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 language: node_js
 node_js:
-  - "8"
+  - "12"
 cache:
   directories:
     - node_modules

--- a/src/cmp/infrastructure/repository/ChainedVendorListRepository.js
+++ b/src/cmp/infrastructure/repository/ChainedVendorListRepository.js
@@ -11,21 +11,26 @@ export default class ChainedVendorListRepository {
     this._saveRemoteVendorListToLocal = saveRemoteVendorListToLocal({
       inMemoryVendorListRepository
     })
+    this._requested = new Map()
   }
 
   getGlobalVendorList({vendorListVersion} = {}) {
-    return Promise.resolve()
-      .then(() => this._getLocalVendorList({vendorListVersion}))
-      .then(
-        globalVendorList =>
-          globalVendorList ||
-          this._getRemoteVendorList({vendorListVersion}).then(
-            globalVendorList =>
-              this._saveRemoteVendorListToLocal({globalVendorList}).then(
-                () => globalVendorList
-              )
-          )
-      )
+    if (!this._requested.has(vendorListVersion)) {
+      const request = Promise.resolve()
+        .then(() => this._getLocalVendorList({vendorListVersion}))
+        .then(
+          globalVendorList =>
+            globalVendorList ||
+            this._getRemoteVendorList({vendorListVersion}).then(
+              globalVendorList =>
+                this._saveRemoteVendorListToLocal({globalVendorList}).then(
+                  () => globalVendorList
+                )
+            )
+        )
+      this._requested.set(vendorListVersion, request)
+    }
+    return this._requested.get(vendorListVersion)
   }
 }
 

--- a/src/test/cmp/infrastructure/repository/ChainedVendorListRepositoryTest.js
+++ b/src/test/cmp/infrastructure/repository/ChainedVendorListRepositoryTest.js
@@ -79,7 +79,7 @@ describe('ChainedVendorListRepository', () => {
           expect(
             inMemoryGetGlobalVendorListSpy.callCount,
             'should have called the inmemory repository to get the vendor list from there first'
-          ).to.be.equal(calls.length)
+          ).to.be.equal(1)
           results.forEach(result =>
             expect(
               result.value,


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

As validated in the first commit: https://github.com/scm-spain/boros-CMP/commit/4192a37c5c953b3f9d5971bebdec6b3225257671

The chained vendor list repository was not working as expected: instead of reading from the inmemory repo and delegating to the http one only when the inmemory data was not existing, in the case of N simultaneous requests, as it's resolved in async mode, the chained repo was delegating part of the N promises to the http repo, so it was doing N HTTP requests instead of 1 for the same global vendor list JSON resource.

![image](https://user-images.githubusercontent.com/20399660/74226843-99239f80-4cbd-11ea-95ad-e39822c314d4.png)


## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* Investigate CMP's JSONs multiple downloads (https://jira.scmspain.com/browse/PSP-2878)

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

When a vendor list is requested:
- the chained repo looks into its requested vendor lists maps, and
  - if not found, creates a promise request that will find into the inmemory and the http as fallback like before, and saves this request for next calls
  - if found, returns the saved promise request

## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

* the behavior was random in real environments, it was forced by a test

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/KgFDNIp5mRbxmYbUCZ/giphy.gif)