### PR TITLE
Hotfix/latest vendorlist

### DIFF
--- a/src/cmp/infrastructure/repository/HttpTranslationVendorListRepository.js
+++ b/src/cmp/infrastructure/repository/HttpTranslationVendorListRepository.js
@@ -29,7 +29,9 @@ export default class HttpTranslationVendorListRepository {
       .then(
         () =>
           `${this._vendorListHost}/${
-            vendorListVersion ? 'v-' + vendorListVersion + '/' : ''
+            vendorListVersion && Number(vendorListVersion)
+              ? 'v-' + vendorListVersion + '/'
+              : ''
           }${PURPOSES_FILENAME}-${this._consentLanguage}${PURPOSES_EXTENSION}`
       )
       .then(url => this._fetcher(url))

--- a/src/cmp/infrastructure/repository/HttpVendorListRepository.js
+++ b/src/cmp/infrastructure/repository/HttpVendorListRepository.js
@@ -14,7 +14,9 @@ export default class HttpVendorListRepository {
   getGlobalVendorList({vendorListVersion} = {}) {
     return Promise.resolve(
       this._vendorListHost +
-        (vendorListVersion ? '/v-' + vendorListVersion : '') +
+        (vendorListVersion && Number(vendorListVersion)
+          ? '/v-' + vendorListVersion
+          : '') +
         '/' +
         this._vendorListFilename
     )

--- a/src/test/cmp/infrastructure/repository/HttpTranslationVendorListRepositoryTest.js
+++ b/src/test/cmp/infrastructure/repository/HttpTranslationVendorListRepositoryTest.js
@@ -103,5 +103,38 @@ describe('HttpTranslationVendorListRepository', () => {
         .then(() => done())
         .catch(e => done(e))
     })
+    it('should load the no-version translations if vendor list version is specified as LATEST', done => {
+      const givenConsentLanguage = 'es'
+      const givenVendorListVersion = 'LATEST'
+      const givenVendorListHost = 'https://vendorlist.consensu.org'
+      const expectedTranslationsUrl = `${givenVendorListHost}/purposes-es.json`
+      const fetchTranslationMock = {
+        fetch: () => ({
+          json: () => TranslationES,
+          ok: true
+        })
+      }
+      const fetchTranslationSpy = sinon.spy(fetchTranslationMock, 'fetch')
+      const vendorListMock = {
+        getGlobalVendorList: () => Promise.resolve(GlobalVendorList)
+      }
+      const repository = new HttpTranslationVendorListRepository({
+        fetcher: fetchTranslationMock.fetch,
+        vendorListHost: givenVendorListHost,
+        vendorListRepository: vendorListMock,
+        consentLanguage: givenConsentLanguage
+      })
+      repository
+        .getGlobalVendorList({vendorListVersion: givenVendorListVersion})
+        .then(vendorList => {
+          expect(fetchTranslationSpy.calledOnce).to.be.true
+          expect(
+            fetchTranslationSpy.args[0][0],
+            'incorrect translations URL'
+          ).to.equal(expectedTranslationsUrl)
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
   })
 })

--- a/src/test/cmp/infrastructure/repository/HttpVendorListRepositoryTest.js
+++ b/src/test/cmp/infrastructure/repository/HttpVendorListRepositoryTest.js
@@ -82,5 +82,46 @@ describe('HttpVendorListRepository', () => {
         })
         .catch(e => done(e))
     })
+    it('Should fetch the remote last version of the vendor list JSON, using the given vendor list location, when vendorListVersion is set to LATEST', done => {
+      const givenVendorListHost = 'http://cmp.schibsted.com'
+      const givenVendorListFilename = 'givenVendorList.json'
+      const expectedUrl = 'http://cmp.schibsted.com/givenVendorList.json'
+
+      const expectedResult = {
+        key: 'value'
+      }
+      const fetchMock = {
+        fetch: () => ({
+          json: () => expectedResult,
+          ok: true
+        })
+      }
+      const fetchSpy = sinon.spy(fetchMock, 'fetch')
+
+      const repository = new HttpVendorListRepository({
+        fetcher: fetchMock.fetch,
+        vendorListFilename: givenVendorListFilename,
+        vendorListHost: givenVendorListHost
+      })
+
+      repository
+        .getGlobalVendorList({vendorListVersion: 'LATEST'})
+        .then(result => {
+          expect(
+            fetchSpy.calledOnce,
+            'should have called the remote fetch method'
+          ).to.be.true
+          expect(
+            fetchSpy.args[0][0],
+            'should retrieve the IAB vendor list by default'
+          ).to.equal(expectedUrl)
+          expect(
+            result,
+            'should return the fetched value as json output format'
+          ).to.deep.equal(expectedResult)
+        })
+        .then(() => done())
+        .catch(e => done(e))
+    })
   })
 })


### PR DESCRIPTION
## Description
when asking for the latest version of the vendorList an error occurs. 

## Solves ticket/s
https://jira.scmspain.com/browse/PSP-2887

## Expected behavior
When asking for the latest version, the real petition should be done to /vendorlist.json, without specifying version. With this petition the vendorList returned will be the last one.

## Review steps
Charles it and from the window make this petition: 
```
window.__cmp('getVendorList', 'LATEST', function(data) {console.log('>>>> ', data)})
```
Check in the network for the petition of the vendor.js and the purposes.
![image](https://user-images.githubusercontent.com/26205284/74348669-593ee400-4db3-11ea-8a4a-ce59c630a84a.png)

## Memetized description
![mandatory](https://media.giphy.com/media/Xy1PJMxpqh1jLfl8BA/giphy.gif)